### PR TITLE
Exposes `setAllInteriorPointers`, and upgrade to recent Zig build

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -22,6 +22,11 @@ pub fn build(b: *std.Build) void {
         };
 
         gc.linkLibC();
+
+        if (target.isDarwin()) {
+            gc.linkFramework("Foundation");
+        }
+
         gc.addIncludePath("vendor/bdwgc/include");
         inline for (libgc_srcs) |src| {
             gc.addCSourceFile("vendor/bdwgc/" ++ src, &cflags);

--- a/example/basic.zig
+++ b/example/basic.zig
@@ -17,9 +17,9 @@ pub fn main() !void {
     // it'll stabilize at a certain size.
     var i: u64 = 0;
     while (i < 10_000_000) : (i += 1) {
-        var p = @ptrCast(**u8, try alloc.alloc(*u8, @sizeOf(*u8)));
+        var p: **u8 = @ptrCast(try alloc.alloc(*u8, @sizeOf(*u8)));
         var q = try alloc.alloc(u8, @sizeOf(u8));
-        p.* = @ptrCast(*u8, q);
+        p.* = @ptrCast(q);
         _ = alloc.resize(q, 2 * @sizeOf(u8));
         if (i % 100_000 == 0) {
             const heap = gc.getHeapSize();


### PR DESCRIPTION
I use BoehmGC in a Zig-based interpreter and was plagued by premature collections. The root cause turned out to be interior pointers. I thus propose exposing the API for handling it in this library as well.

`setAllInteriorPointers` is important for many non-trival programs to ensure reachability through interior pointers.

The PR upgrades to a recent build of Zig (0.11.0-dev.4003+c6aa29b6f)

I also had to add `gc.linkFramework("Foundation");` to make the library build on macOS Ventura.